### PR TITLE
Official swapr beta farming contract addresses on mainnet and xdai

### DIFF
--- a/src/commons/addresses.ts
+++ b/src/commons/addresses.ts
@@ -16,9 +16,9 @@ export function getFactoryAddress(): string {
 export function getStakingRewardsFactoryAddress(): string {
   let network = dataSource.network() as string
   // not using a switch-case because using strings is not yet supported (only u32)
-  if (network == 'mainnet') return ADDRESS_ZERO
+  if (network == 'mainnet') return '0x156f0568a6ce827e5d39f6768a5d24b694e1ea7b'
   if (network == 'rinkeby') return '0x163a3640ce993a0b4c11885a6d4dac16dfc188e1'
-  if (network == 'xdai') return '0xcd2a45f36464fdb1065160e03a2353996ea8ff57'
+  if (network == 'xdai') return '0xa039793af0bb060c597362e8155a0327d9b8bee8'
   log.warning('no staking rewards factory address for unsupported network {}', [network])
   return ADDRESS_ZERO
 }

--- a/subgraph.mainnet.yaml
+++ b/subgraph.mainnet.yaml
@@ -31,6 +31,26 @@ dataSources:
       eventHandlers:
         - event: PairCreated(indexed address,indexed address,address,uint256)
           handler: handleNewPair
+  - kind: ethereum/contract
+    name: StakingRewardsFactory
+    network: mainnet
+    source:
+      address: '0x156F0568a6cE827e5d39F6768A5D24B694e1EA7b'
+      abi: StakingRewardsFactory
+      startBlock: 12583353
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/staking-rewards.ts
+      entities:
+        - Distribution
+      abis:
+        - name: StakingRewardsFactory
+          file: ./abis/staking-rewards-factory.json
+      eventHandlers:
+        - event: DistributionCreated(address,address)
+          handler: handleDistributionCreation
 templates:
   - kind: ethereum/contract
     name: Pair
@@ -61,3 +81,36 @@ templates:
           handler: handleTransfer
         - event: Sync(uint112,uint112)
           handler: handleSync
+  - kind: ethereum/contract
+    name: Distribution
+    network: mainnet
+    source:
+      abi: StakingRewardsDistribution
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      file: ./src/mappings/staking-rewards.ts
+      entities:
+        - Deposit
+        - Withdrawal
+        - Claim
+        - Recovery
+      abis:
+        - name: StakingRewardsDistribution
+          file: ./abis/staking-rewards-distribution.json
+      eventHandlers:
+        - event: Initialized(address[],address,uint256[],uint64,uint64,bool,uint256)
+          handler: handleDistributionInitialization
+        - event: Canceled()
+          handler: handleCancelation
+        - event: Staked(indexed address,uint256)
+          handler: handleDeposit
+        - event: Withdrawn(indexed address,uint256)
+          handler: handleWithdrawal
+        - event: Claimed(indexed address,uint256[])
+          handler: handleClaim
+        - event: Recovered(uint256[])
+          handler: handleRecovery
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleOwnershipTransfer

--- a/subgraph.xdai.yaml
+++ b/subgraph.xdai.yaml
@@ -35,9 +35,9 @@ dataSources:
     name: StakingRewardsFactory
     network: xdai
     source:
-      address: '0xCD2A45F36464FdB1065160e03A2353996Ea8Ff57'
+      address: '0xa039793Af0bb060c597362E8155a0327d9b8BEE8'
       abi: StakingRewardsFactory
-      startBlock: 15710884
+      startBlock: 16517765
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.4


### PR DESCRIPTION
After the proposal for Swapr beta was submitted, the addresses for the farming contracts on mainnet and xDai have been made public. This PR uses them where they're needed.